### PR TITLE
fix: add fetch import back to request

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -1,3 +1,5 @@
+import fetch from 'node-fetch'
+
 import { StravaError } from './errors'
 import { RefreshTokenRequest, RefreshTokenResponse } from './types'
 


### PR DESCRIPTION
Current build is broken.

```
ReferenceError: fetch is not defined
    at response (C:\Websites\gym.com\node_modules\strava\src\request.ts:27:10)
    at t.getAccessToken (C:\Websites\gym.com\node_modules\strava\src\request.ts:40:12)
    at error (C:\Websites\gym.com\node_modules\strava\src\request.ts:51:18)
    at t.r.makeApiRequest (C:\Websites\gym.com\node_modules\strava\src\request.ts:73:14)
    at e.t.getSubscriptions (C:\Websites\gym.com\node_modules\strava\src\resources\subscriptions.ts:43:13)
    at StravaWebhooksController.<anonymous> (C:\Websites\gym.com\dist\apps\gym-api\webpack:\apps\gym-api\src\app\webhooks\controllers\strava.controller.ts:42:63)
    at Generator.next (<anonymous>)
    at C:\Websites\gym.com\node_modules\tslib\tslib.js:117:75
    at new Promise (<anonymous>)
    at __awaiter (C:\Websites\gym.com\node_modules\tslib\tslib.js:113:16)
```

https://github.com/rfoel/strava/commit/4aff19838370db891245fcea6f138c7e414b38fd#diff-b1a2ab03a3672e105afeaab6615ad625365cd8459d592a840d925f132af62b35L1