### PR TITLE
fix: add LatLng type for streams and start/end positions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import {
 } from './resources'
 import { RefreshTokenRequest } from './types'
 
+export * from './types'
 export * from './enums'
 export * from './models'
 

--- a/src/models/detailedActivity.ts
+++ b/src/models/detailedActivity.ts
@@ -1,4 +1,5 @@
 import { ActivityType, ResourceState } from '../enums'
+import { LatLng } from '../types'
 
 import {
   ActivityZone,
@@ -29,8 +30,8 @@ export interface DetailedActivity {
   start_date_local: string
   timezone: string
   utc_offset: number
-  start_latlng: number[]
-  end_latlng: number[]
+  start_latlng: LatLng
+  end_latlng: LatLng
   location_city: string
   location_state: string
   location_country: string

--- a/src/models/detailedSegment.ts
+++ b/src/models/detailedSegment.ts
@@ -1,4 +1,5 @@
 import { PolylineMap, SummaryPRSegmentEffort, SummarySegmentEffort } from '.'
+import { LatLng } from '../types';
 
 enum ActivityType {
   Ride = 'Ride',
@@ -14,8 +15,8 @@ export interface DetailedSegment {
   maximum_grade: number
   elevation_high: number
   elevation_low: number
-  start_latlng: number[]
-  end_latlng: number[]
+  start_latlng: LatLng
+  end_latlng: LatLng
   climb_category: number
   city: string
   state: string

--- a/src/models/explorerSegment.ts
+++ b/src/models/explorerSegment.ts
@@ -1,3 +1,5 @@
+import { LatLng } from "../types";
+
 enum ClimbCategoryDesc {
   NC = 'NC',
   ONE = '1',
@@ -13,8 +15,8 @@ export interface ExplorerSegment {
   climb_category: number
   climb_category_desc: ClimbCategoryDesc
   avg_grade: number
-  start_latlng: number[]
-  end_latlng: number[]
+  start_latlng: LatLng
+  end_latlng: LatLng
   elev_difference: number
   distance: number
   points: string

--- a/src/models/stream.ts
+++ b/src/models/stream.ts
@@ -1,18 +1,25 @@
-export interface Stream {
-  type:
-    | 'time'
-    | 'distance'
-    | 'latlng'
-    | 'altitude'
-    | 'velocity_smooth'
-    | 'heartrate'
-    | 'cadence'
-    | 'watts'
-    | 'temp'
-    | 'moving'
-    | 'grade_smooth'
+import { LatLng, StreamKeys } from '..'
+
+export interface BaseStream<StreamKey extends StreamKeys, Data> {
+  type: StreamKey
   original_size: number
   resolution: 'low' | 'medium' | 'high'
   series_type: 'distance' | 'time'
-  data: number[]
+  data: Data[]
 }
+
+export type Stream = BaseStream<
+  | 'time'
+  | 'distance'
+  | 'altitude'
+  | 'velocity_smooth'
+  | 'heartrate'
+  | 'cadence'
+  | 'watts'
+  | 'temp'
+  | 'moving'
+  | 'grade_smooth',
+  number
+>
+
+export type LatLngStream = BaseStream<'latlng', LatLng>

--- a/src/models/streamSet.ts
+++ b/src/models/streamSet.ts
@@ -1,9 +1,9 @@
-import { Stream } from '.'
+import { LatLngStream, Stream } from '.'
 
 export interface StreamSet {
   time: Stream
   distance: Stream
-  latlng: Stream
+  latlng: LatLngStream
   altitude: Stream
   velocity_smooth: Stream
   heartrate: Stream

--- a/src/models/summaryActivity.ts
+++ b/src/models/summaryActivity.ts
@@ -1,4 +1,5 @@
 import { ActivityType, ResourceState } from '../enums'
+import { LatLng } from '../types'
 
 import { MetaAthlete, PolylineMap } from '.'
 
@@ -19,8 +20,8 @@ export interface SummaryActivity {
   start_date_local: string
   timezone: string
   utc_offset: number
-  start_latlng: number[]
-  end_latlng: number[]
+  start_latlng: LatLng
+  end_latlng: LatLng
   location_city: string
   location_state: string
   location_country: string

--- a/src/models/summarySegment.ts
+++ b/src/models/summarySegment.ts
@@ -1,4 +1,5 @@
 import { SummarySegmentEffort } from '.'
+import { LatLng } from '../types';
 
 enum ActivityType {
   Ride = 'Ride',
@@ -14,8 +15,8 @@ export interface SummarySegment {
   maximum_grade: number
   elevation_high: number
   elevation_low: number
-  start_latlng: number[]
-  end_latlng: number[]
+  start_latlng: LatLng
+  end_latlng: LatLng
   climb_category: number
   city: string
   state: string

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,3 +10,8 @@ export interface RefreshTokenResponse {
   expires_in: number
   refresh_token: string
 }
+
+/**
+ * Latitude, Longitude
+ */
+export type LatLng = [number, number]


### PR DESCRIPTION
👋 Thanks for this library, especially the types!

 I noticed that geo locations (latitude, longitude) are not correctly typed:

* Geo locations are specified as `number[]` for `start_latlng` and `end_latlng` which includes arrays of more or less than 2 items. We know that geo locations are always a tuple of 2. I introduced the type `LatLng` which is more precise: `[number, number]`.
* The type within `StreamSet` for `latlng` was `number[]` instead of `LatLng[]`. This also required some restructuring around the existing types to avoid duplications. Not sure if you like the new types/structure, so feel free to adjust.
* I exported the `./types` file as the `LatLng` type was created in there. This also fixes another issue where `RefreshTokenRequest` and `RefreshTokenResponse` were not exported and could only be imported from `strava/dist/types`