### PR TITLE
Allow initialization with access token or token exchange code

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,4 +140,4 @@ Issues and pull requests are welcome.
 
 ## License
 
-[MIT](https://github.com/rfoell/strava/blob/master/LICENSE)
+[MIT](https://github.com/rfoel/strava/blob/master/LICENSE)

--- a/README.md
+++ b/README.md
@@ -23,9 +23,8 @@ yarn add strava
 
 ## Usage
 
-The way the library is implemented the user must have gone through the [Strava OAuth flow](https://developers.strava.com/docs/authentication/) beforehand and got a refresh token. This way we can ensure that whenever needed we get a new access token.
-
-This may not be the best way to work with the API and I'm open to suggestions to make it better.
+The library can be initialized with a refresh token and optionally an access token.
+If these are not available, see below (**Token exchange**).
 
 ```javascript
 import { Strava } from 'strava'
@@ -36,30 +35,103 @@ const strava = new Strava({
   refresh_token: 'def',
 })
 
-;(async () => {
-  try {
-    const activities = await strava.activities.getLoggedInAthleteActivities()
-    console.log(activities)
-  } catch (error) {
-    console.log(error)
-  }
-})()
+try {
+  const activities = await strava.activities.getLoggedInAthleteActivities()
+  console.log(activities)
+} catch (error) {
+  console.log(error)
+}
 ```
 
 ### Refreshing the access token
 
-This library will automatically refresh the access token when needed. You may need to store the refresh token somewhere, so you can use it `on_token_refresh` callback.
+This library will automatically refresh the access token when needed.
+In order to store the token, you can use the `on_token_refresh` callback.
+This received an `AccessToken` object (consisting of `access_token`, `expires_at`, and `refresh_token`).
+Note that the refresh token as returned by this call can sometimes change,
+at which point the old token becomes invalid.
+
+An `AccessToken` object can also be passed as a second argument to the Strava constructor.
+This can save an initial token refresh.
+As `AccessToken` contains a refresh token,
+the first argument does not need to contain a refresh token.
+
 ```javascript
 import { Strava } from 'strava'
 
-const strava = new Strava({
-  client_id: '123',
-  client_secret: 'abc',
-  refresh_token: 'def',
-  on_token_refresh: (response: RefreshTokenResponse) => {
-    db.set('refresh_token', response.refresh_token)
-  }
-})
+const strava = new Strava(
+  {
+    client_id: '123',
+    client_secret: 'abc',
+
+    on_token_refresh: response => {
+      cache.accessToken = response
+    },
+  },
+  cache.accessToken,
+)
+```
+
+### Token exchange
+
+When a user logs in for the first time, you will need to perform authorization with OAuth.
+This involves sending the user to <https://www.strava.com/oauth/authorize>,
+and receiving the auth code as a query parameter.
+
+This can be used as follows:
+
+```javascript
+import { Strava } from 'strava'
+
+try {
+  const strava = await Strava.createFromTokenExchange(
+    {
+      client_id: '123',
+      client_secret: 'abc',
+    },
+    token,
+  )
+
+  const activities = await strava.activities.getLoggedInAthleteActivities()
+  console.log(activities)
+} catch (error) {
+  console.log(error)
+}
+```
+
+### Getting athlete info
+
+When a user logs in for the first time, the Strava API returns information about the newly logged-in user.
+This can be read using the on_token_refresh callback.
+Note that this will only ever be provided on the initial token exchange,
+before the promise returned from `Strava.createFromTokenExchange` returns.
+When the `on_token_refresh` callback is called again after the token expires,
+`response.athlete` will always be undefined.
+
+```javascript
+import { Strava } from 'strava'
+
+try {
+  const strava = await Strava.createFromTokenExchange(
+    {
+      client_id: '123',
+      client_secret: 'abc',
+      on_token_refresh: response => {
+        if (response.athlete) {
+          console.log(response.athlete)
+        }
+
+        db.set('refresh_token', response.refresh_token)
+      },
+    },
+    token,
+  )
+
+  const activities = await strava.activities.getLoggedInAthleteActivities()
+  console.log(activities)
+} catch (error) {
+  console.log(error)
+}
 ```
 
 ## Contributing

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import {
   Uploads,
 } from './resources'
 import { Oauth } from './resources/oauth'
-import { RefreshTokenRequest } from './types'
+import { AccessToken, RefreshTokenRequest } from './types'
 
 export * from './types'
 export * from './enums'
@@ -34,13 +34,13 @@ export class Strava {
   subscriptions: Subscriptions
   uploads: Uploads
 
-  constructor(config: RefreshTokenRequest) {
-    this.request = new Request(config)
+  constructor(config: RefreshTokenRequest, access_token?: AccessToken) {
+    this.request = new Request(config, access_token)
     this.activities = new Activities(this.request)
     this.athletes = new Athletes(this.request)
     this.clubs = new Clubs(this.request)
     this.gears = new Gears(this.request)
-    this.oauth = new Oauth()
+    this.oauth = this.request.oauth
     this.routes = new Routes(this.request)
     this.runningRaces = new RunningRaces(this.request)
     this.segmentEfforts = new SegmentEfforts(this.request)

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import {
   Uploads,
 } from './resources'
 import { Oauth } from './resources/oauth'
-import { AccessToken, RefreshTokenRequest } from './types'
+import { AccessToken, AppConfig, RefreshTokenRequest } from './types'
 
 export * from './types'
 export * from './enums'
@@ -21,19 +21,21 @@ export * from './models'
 
 export class Strava {
   private readonly request: Request
-  activities: Activities
-  athletes: Athletes
-  clubs: Clubs
-  gears: Gears
-  oauth: Oauth
-  routes: Routes
-  runningRaces: RunningRaces
-  segmentEfforts: SegmentEfforts
-  segments: Segments
-  streams: Streams
-  subscriptions: Subscriptions
-  uploads: Uploads
+  readonly activities: Activities
+  readonly athletes: Athletes
+  readonly clubs: Clubs
+  readonly gears: Gears
+  readonly oauth: Oauth
+  readonly routes: Routes
+  readonly runningRaces: RunningRaces
+  readonly segmentEfforts: SegmentEfforts
+  readonly segments: Segments
+  readonly streams: Streams
+  readonly subscriptions: Subscriptions
+  readonly uploads: Uploads
 
+  constructor(config: RefreshTokenRequest, access_token?: AccessToken)
+  constructor(config: AppConfig, access_token: AccessToken)
   constructor(config: RefreshTokenRequest, access_token?: AccessToken) {
     this.request = new Request(config, access_token)
     this.activities = new Activities(this.request)
@@ -48,5 +50,11 @@ export class Strava {
     this.streams = new Streams(this.request)
     this.subscriptions = new Subscriptions(this.request)
     this.uploads = new Uploads(this.request)
+  }
+
+  static async createFromTokenExchange(config: AppConfig, code: string) {
+    const tokenExchangeResponse = await Oauth.tokenExchange(config, code)
+    config.on_token_refresh?.(tokenExchangeResponse)
+    return new Strava(config, tokenExchangeResponse)
   }
 }

--- a/src/request.ts
+++ b/src/request.ts
@@ -25,7 +25,8 @@ export class Request {
       const query: string = new URLSearchParams({
         client_id: this.config.client_id,
         client_secret: this.config.client_secret,
-        refresh_token: this.config.refresh_token,
+        refresh_token:
+          this.response?.refresh_token || this.config.refresh_token,
         grant_type: 'refresh_token',
       }).toString()
 

--- a/src/resources/oauth.ts
+++ b/src/resources/oauth.ts
@@ -3,27 +3,22 @@ import fetch from 'node-fetch'
 import { RefreshTokenRequest, RefreshTokenResponse } from '../types'
 
 export class Oauth {
-  constructor() {}
-
   async refreshTokens(
     token: RefreshTokenRequest,
   ): Promise<RefreshTokenResponse> {
     if (!token) {
       throw new Error('No token provided')
     }
-    const query: string = new URLSearchParams({
-      client_id: token.client_id,
-      client_secret: token.client_secret,
-      refresh_token: token.refresh_token,
-      grant_type: 'refresh_token',
-    }).toString()
 
-    const response = await fetch(
-      `https://www.strava.com/oauth/token?${query}`,
-      {
-        method: 'post',
-      },
-    )
+    const response = await fetch(`https://www.strava.com/oauth/token`, {
+      body: new URLSearchParams({
+        client_id: token.client_id,
+        client_secret: token.client_secret,
+        refresh_token: token.refresh_token,
+        grant_type: 'refresh_token',
+      }),
+      method: 'post',
+    })
     if (!response.ok) {
       throw response
     }

--- a/src/resources/oauth.ts
+++ b/src/resources/oauth.ts
@@ -1,6 +1,6 @@
 import fetch from 'node-fetch'
 
-import { RefreshTokenRequest, RefreshTokenResponse } from '../types'
+import { AppConfig, RefreshTokenRequest, RefreshTokenResponse } from '../types'
 
 export class Oauth {
   async refreshTokens(
@@ -9,14 +9,33 @@ export class Oauth {
     if (!token) {
       throw new Error('No token provided')
     }
-
-    const response = await fetch(`https://www.strava.com/oauth/token`, {
-      body: new URLSearchParams({
+    return await Oauth.oauthRequest(
+      new URLSearchParams({
         client_id: token.client_id,
         client_secret: token.client_secret,
         refresh_token: token.refresh_token,
         grant_type: 'refresh_token',
       }),
+    )
+  }
+
+  static async tokenExchange(config: AppConfig, code: string) {
+    if (!code) {
+      throw new Error('No code provided')
+    }
+    return await Oauth.oauthRequest(
+      new URLSearchParams({
+        client_id: config.client_id,
+        client_secret: config.client_secret,
+        code,
+        grant_type: 'authorization_code',
+      }),
+    )
+  }
+
+  private static async oauthRequest(body: URLSearchParams) {
+    const response = await fetch(`https://www.strava.com/oauth/token`, {
+      body,
       method: 'post',
     })
     if (!response.ok) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,14 +1,21 @@
-export interface RefreshTokenRequest {
+export interface AppConfig {
   client_id: string
   client_secret: string
-  refresh_token: string
   on_token_refresh?: (token: RefreshTokenResponse) => void
 }
-export interface RefreshTokenResponse {
+
+export interface RefreshTokenRequest extends AppConfig {
+  refresh_token: string
+}
+
+export interface AccessToken {
   access_token: string
   expires_at: number
+  refresh_token?: string
+}
+
+export interface RefreshTokenResponse extends AccessToken {
   expires_in: number
-  refresh_token: string
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import { SummaryAthlete } from './models'
+
 export interface AppConfig {
   client_id: string
   client_secret: string
@@ -16,6 +18,8 @@ export interface AccessToken {
 
 export interface RefreshTokenResponse extends AccessToken {
   expires_in: number
+  /** The athlete is only provided on the initial request */
+  athlete?: SummaryAthlete
 }
 
 /**

--- a/test/mocks.ts
+++ b/test/mocks.ts
@@ -4,7 +4,8 @@ import nock from 'nock'
 export const auth = () => {
   nock('https://www.strava.com')
     .post(
-      '/oauth/token?client_id=client_id&client_secret=client_secret&refresh_token=refresh_token&grant_type=refresh_token',
+      '/oauth/token',
+      'client_id=client_id&client_secret=client_secret&refresh_token=refresh_token&grant_type=refresh_token',
     )
     .reply(200, {})
   return new Strava({


### PR DESCRIPTION
This creates two new ways of initializing the Strava object: with an access token and with a token exchange code.

```ts
// Previous, still works:
const strava = new Strava({
  client_id: '123',
  client_secret: 'abc',
  refresh_token: 'def',

  // optional
  on_token_refresh: (token) => saveToken(token),
})

// New, with access token
strava = new Strava({
  client_id: '123',
  client_secret: 'abc',

  //optional
  on_token_refresh: (token) => saveToken(token),
}, {
  access_token: 'XYZ',
  expires_at: 1800000000,
  refresh_token: 'ABC',
})

// New, with token exchange code
strava = await Strava.createFromTokenExchange({
  client_id: '123',
  client_secret: 'abc',

  // optional
  on_token_refresh: (token) => saveToken(token),
), 'code-xyz');
```

### Bug fixed

In the first commit of the PR, I fixed the issue that the original refresh token is used for all refreshes, even if a new refresh token has been provided.

### Open for discussion

Is this interface sensible? The multiple parameters do not look as nice as the previous single parameter, but

- it’s preferable to be able to cache and restore the entire token object.
- everything in the first parameter is safe to be stored in the Request constructor, it will never change*

\* Except for the request_token, which can change over time

#### A couple of alternatives:

**A1**:
```ts
strava = new Strava({
  client_id: '123',
  client_secret: 'abc',

  token: {
    access_token: 'XYZ',
    expires_at: 1800000000,
    refresh_token: 'ABC',
  },

  //optional
  on_token_refresh: (token) => saveToken(token),
})

strava = await Strava.createFromTokenExchange({
  client_id: '123',
  client_secret: 'abc',

  code: 'code-xyz',

  //optional
  on_token_refresh: (token) => saveToken(token),
})
```

- a single object, looks nicer
- clear labels of what the code/access_token are.
- it would be problematic to store the whole object in the `Request` constructor, because the `token` becomes outdated quickly. Instead, `client_id`, `client_secret` and `on_token_refresh` would each have to be stored separately.

**A2**:
```ts
strava = new Strava({
  client: { client_id: '123', client_secret: 'abc' },

  token: {
    access_token: 'XYZ',
    expires_at: 1800000000,
    refresh_token: 'ABC',
  },

  //optional
  on_token_refresh: (token) => saveToken(token),
})

strava = await Strava.createFromTokenExchange({
  client: { client_id: '123', client_secret: 'abc' },

  code: 'code-xyz',

  //optional
  on_token_refresh: (token) => saveToken(token),
})
```

- a single object, looks nicer
- clear labels of what the code/access_token are.
- the same client object can be passed for all calls from all users, as it is always the same.
- only two items to save in the Request constructor: `client` and `on_token_refresh`.
- less compatible with the previous solution, so more code required for interim.